### PR TITLE
WIP - Better handling of XML namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-# EPP Server
+# EPP Go - Extensible Provisioning Protocol Server and Client
 
-This is an implementation of how to handle EPP requests concurrently.
+This is an implementation of how to handle EPP requests concurrently, both as a
+client and as a server. The main focus lays implementing types that may be used
+both as a client and as a server. These types should be easy to use and support
+all the allowed ways of setting up name spaces, attributes and tags. With the
+types implemented the initial focus will be to ensure a complete server
+implementation may be created. Since this is registry specific there will
+probably only be minor helpers and wrappers.
 
 ## NOTE
 
@@ -10,16 +16,14 @@ private project and an experiment to work with XSD files and XML with Go.**
 
 ## Client
 
-A good way to test the implementation of this server is to use an existing and
-tested client to ensure communication works as epxected.
+To quickly get up and running and support testing of the server the repository
+contains a set of real world examples of EPP commands foudn in
+[xml/commands](xml/commands).
 
-Example clients:
-
-* [Domainr EPP client in Go (WIP)](https://github.com/domainr/epp)
-* [python-epp-client](https://github.com/Darkfish/python-epp-client)
-
-Even this package includes a test client which can send XML to the EPP server
-although no validation or verificate is made.
+Inside the [example](example/client) folder there's a client utilizing a few of
+the types and all of the read/writering confirming to EPP RFC. This client reads
+from STDIN so it's just to copy and paste any of the example XML file contents
+to test changes.
 
 ## References
 
@@ -56,9 +60,9 @@ XML files are linted with [`xmllint`](http://xmlsoft.org/xmllint.html).
 
 To validate XML [`libxml2` (bindings for
 Go)](https://github.com/lestrrat-go/libxml2/) is used. This package requires you
-to install the [`libxml2`](http://xmlsoft.org/downloads.html) C bindings.
+to install the [`libxml2`](http://xmlsoft.org/downloads.html) C libraries.
 
-## Installation macOS
+### Installation macOS
 
 Since macOS 10.14 [brew](https://brew.sh/) won't link packages and libraries
 bundlede with maCOS. This includes `libxml2` and it's header files.

--- a/README.md
+++ b/README.md
@@ -57,3 +57,15 @@ XML files are linted with [`xmllint`](http://xmlsoft.org/xmllint.html).
 To validate XML [`libxml2` (bindings for
 Go)](https://github.com/lestrrat-go/libxml2/) is used. This package requires you
 to install the [`libxml2`](http://xmlsoft.org/downloads.html) C bindings.
+
+## Installation macOS
+
+Since macOS 10.14 [brew](https://brew.sh/) won't link packages and libraries
+bundlede with maCOS. This includes `libxml2` and it's header files.
+
+```sh
+$ brew install libxml2
+
+$ PKG_CONFIG_PATH="/usr/local/opt/libxml2/lib/pkgconfig" \
+    go get github.com/lestrrat-go/libxml2/...
+```

--- a/client.go
+++ b/client.go
@@ -75,7 +75,7 @@ func (c *Client) Login(username, password string) ([]byte, error) {
 		},
 	}
 
-	encoded, err := Encode(login, ClientXMLAttributes(), "")
+	encoded, err := Encode(login, ClientXMLAttributes())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/type-generator/main.go
+++ b/cmd/type-generator/main.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+var templateData = `package {{.Package}}
+
+/*
+NOTE! This file is auto generated from another file - DO NOT EDIT!
+
+This file contents has it's source in {{.Filename}}. All structs with only one
+field and the suffix 'Type' is being added here. The difference is that the
+field XML tag won't have a namespace.
+*/
+
+{{ range $t := .Types -}}
+// {{$t.StructName}} represents a namespace agnostic version of {{$t.OriginalStructName}}
+type {{$t.StructName}} struct {
+	{{$t.FieldName}} {{$t.FieldType}} {{$t.FieldTag}}
+}
+
+{{ end -}}
+`
+
+// typeData holds all the stucts with type suffix that should be re-generated
+// with a trimmed XML tag.
+type typeData struct {
+	Package  string
+	Filename string
+	Types    []typeStruct
+}
+
+type typeStruct struct {
+	OriginalStructName string
+	StructName         string
+	FieldName          string
+	FieldType          string
+	FieldTag           string
+}
+
+func main() {
+	var (
+		args  []string
+		help  bool
+		files = []string{}
+	)
+
+	flag.BoolVar(&help, "h", false, "Show this help text")
+	flag.BoolVar(&help, "help", false, "")
+
+	flag.Parse()
+
+	if help {
+		showHelp()
+
+		return
+	}
+
+	args = flag.Args()
+	if len(args) == 0 {
+		args = []string{"./types/..."}
+	}
+
+	for _, f := range args {
+		if strings.HasSuffix(f, "/...") {
+			dir, _ := filepath.Split(f)
+
+			files = append(files, expandGoWildcard(dir)...)
+
+			continue
+		}
+
+		// Skip files already auto-generated.
+		if strings.HasSuffix(f, "auto_generated.go") {
+			continue
+		}
+
+		if _, err := os.Stat(f); err == nil {
+			files = append(files, f)
+		}
+	}
+
+	for _, f := range files {
+		Process(f)
+	}
+
+	return
+}
+
+func Process(filename string) {
+	fileData, err := ioutil.ReadFile(filename)
+	if err != nil {
+		panic(err)
+	}
+
+	fset := token.NewFileSet()
+
+	file, err := parser.ParseFile(fset, filename, fileData, parser.ParseComments)
+	if err != nil {
+		panic(err)
+	}
+
+	typeStructs := typeData{
+		Package:  file.Name.Name,
+		Filename: filename,
+		Types:    []typeStruct{},
+	}
+
+	// Find all structs defined with only one field and has the suffix "Type"
+	for _, x := range file.Decls {
+		v, ok := x.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+
+		for _, s := range v.Specs {
+			spec, ok := s.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+
+			structName := spec.Name.Name
+
+			if !strings.HasSuffix(structName, "Type") {
+				continue
+			}
+
+			structType, ok := spec.Type.(*ast.StructType)
+			if !ok {
+				continue
+			}
+
+			if len(structType.Fields.List) != 1 {
+				continue
+			}
+
+			firstFieldInStruct := structType.Fields.List[0]
+
+			typeStructs.Types = append(typeStructs.Types, typeStruct{
+				OriginalStructName: spec.Name.Name,
+				FieldName:          firstFieldInStruct.Names[0].Name,
+				FieldType:          firstFieldInStruct.Type.(*ast.Ident).Name,
+				FieldTag:           firstFieldInStruct.Tag.Value,
+			})
+		}
+	}
+
+	createFile(typeStructs)
+}
+
+func createFile(data typeData) {
+	for i, d := range data.Types {
+		tagParts := strings.Split(d.FieldTag, "\"")
+		middleParts := strings.Split(tagParts[1], " ")
+
+		data.Types[i].FieldTag = fmt.Sprintf("`xml:\"%s\"`", middleParts[1])
+		data.Types[i].StructName = fmt.Sprintf("%sIn", d.OriginalStructName)
+	}
+
+	tmpl := template.Must(template.New("").Parse(templateData))
+	buf := bytes.Buffer{}
+
+	if err := tmpl.Execute(&buf, data); err != nil {
+		panic(err)
+	}
+
+	fileBytes, err := format.Source(buf.Bytes())
+	if err != nil {
+		panic(err)
+	}
+
+	dir, file := filepath.Split(data.Filename)
+	filenameParts := strings.Split(file, ".")
+	newFilename := fmt.Sprintf("%s_auto_generated.go", strings.Join(filenameParts[:len(filenameParts)-1], "."))
+	newFilepath := filepath.Join(dir, newFilename)
+
+	_ = ioutil.WriteFile(newFilepath, fileBytes, 0644)
+	fmt.Printf("Generated file: %s\n", newFilename)
+}
+
+func expandGoWildcard(root string) []string {
+	foundFiles := []string{}
+
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		// Skip files already auto-generated.
+		if strings.HasSuffix(info.Name(), "auto_generated.go") {
+			return nil
+		}
+
+		// Only append go files
+		if !strings.HasSuffix(info.Name(), ".go") {
+			return nil
+		}
+
+		foundFiles = append(foundFiles, path)
+
+		return nil
+	})
+
+	return foundFiles
+}
+
+func showHelp() {
+	helpText := `Usage: type-generator <file> [files...]
+
+Will default to all files in ./types
+
+Flags:`
+
+	fmt.Println(helpText)
+	flag.PrintDefaults()
+}

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -32,6 +32,8 @@ func main() {
 
 	fmt.Println(string(greeting))
 
+	fmt.Println("---- Enter EPP frame terminated by a double newline ----")
+
 	fmt.Println("> Automatic login!")
 	time.Sleep(1 * time.Second)
 
@@ -42,6 +44,8 @@ func main() {
 	}
 
 	fmt.Println(string(response))
+
+	fmt.Println("---- Enter EPP frame terminated by a double newline ----")
 
 	for {
 		scnr := bufio.NewScanner(os.Stdin)
@@ -55,6 +59,7 @@ func main() {
 
 		scnr.Scan()
 		data := scnr.Bytes()
+
 		if scnr.Err() != nil {
 			log.Fatal(scnr.Err().Error())
 		}

--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -133,9 +133,7 @@ func login(s *epp.Session, data []byte) ([]byte, error) {
 }
 
 func infoDomainWithExtension(s *epp.Session, data []byte) ([]byte, error) {
-	di := struct {
-		Data types.DomainInfo `xml:"command>info>info"`
-	}{}
+	di := types.DomainInfoTypeIn{}
 
 	if err := xml.Unmarshal(data, &di); err != nil {
 		return nil, err
@@ -146,7 +144,7 @@ func infoDomainWithExtension(s *epp.Session, data []byte) ([]byte, error) {
 	// Construct the response with basic data.
 	diResponse := types.DomainInfoDataType{
 		InfoData: types.DomainInfoData{
-			Name: di.Data.Name.Name,
+			Name: di.Info.Name.Name,
 			ROID: "DOMAIN_0000000000-SE",
 			Status: []types.DomainStatus{
 				{
@@ -154,8 +152,8 @@ func infoDomainWithExtension(s *epp.Session, data []byte) ([]byte, error) {
 				},
 			},
 			Host: []string{
-				fmt.Sprintf("ns1.%s", di.Data.Name.Name),
-				fmt.Sprintf("ns2.%s", di.Data.Name.Name),
+				fmt.Sprintf("ns1.%s", di.Info.Name.Name),
+				fmt.Sprintf("ns2.%s", di.Info.Name.Name),
 			},
 			ClientID: "Some Client",
 			CreateID: "Some Client",

--- a/read_write.go
+++ b/read_write.go
@@ -91,14 +91,14 @@ func ServerXMLAttributes() []xml.Attr {
 		{
 			Name: xml.Name{
 				Space: "",
-				Local: "xsi",
+				Local: "xmlns:xsi",
 			},
 			Value: "http://www.w3.org/2001/XMLSchema-instance",
 		},
 		{
 			Name: xml.Name{
-				Space: "xsi",
-				Local: "schemaLocation",
+				Space: "",
+				Local: "xsi:schemaLocation",
 			},
 			Value: "urn:ietf:params:xml:ns:epp-1.0 epp-1.0.xsd",
 		},

--- a/read_write_test.go
+++ b/read_write_test.go
@@ -103,7 +103,7 @@ func TestEncode(t *testing.T) {
 </epp>
 `)
 
-	encoded, err := Encode(dc, ClientXMLAttributes(), "domain")
+	encoded, err := Encode(dc, ClientXMLAttributes())
 
 	require.Nil(t, err)
 	assert.Equal(t, expectedXMLWithNS, encoded)
@@ -149,4 +149,108 @@ func TestDecode(t *testing.T) {
 	assert.Equal(t, "contact-00002", dc.Contacts[1].Name, "contact found")
 	assert.Equal(t, "admin", dc.Contacts[1].Type, "contact type found")
 	assert.Equal(t, "some-password", dc.AuthInfo.Password, "auth info found")
+}
+
+func ExampleAddNamespace() {
+	// Construct the response with basic data.
+	diResponse := types.DomainInfoDataType{
+		InfoData: types.DomainInfoData{
+			Name: "example.se",
+			ROID: "DOMAIN_0000000000-SE",
+			Status: []types.DomainStatus{
+				{
+					DomainStatusType: types.DomainStatusOk,
+				},
+			},
+			Host: []string{
+				"ns1.example.se", "ns2.example.se",
+			},
+			ClientID: "Some Client",
+			CreateID: "Some Client",
+			UpdateID: "Some Client",
+		},
+	}
+
+	// Add extension data from extension iis-1.2.
+	diIISExtensionResponse := types.IISExtensionInfoDataType{
+		InfoData: types.IISExtensionInfoData{
+			State:        "active",
+			ClientDelete: false,
+		},
+	}
+
+	// ADd extension data from secDNS-1.1.
+	diDNSSECExtensionResponse := types.DNSSECExtensionInfoDataType{
+		InfoData: types.DNSSECOrKeyData{
+			DNSSECData: []types.DNSSEC{
+				{
+					KeyTag:     195550,
+					Algorithm:  3,
+					DigestType: 5,
+					Digest:     "FFAB0102FFAB0102FFAB0102FFAB0102FFAB0102FFAB0102FFAB0102FFAB0102",
+				},
+			},
+		},
+	}
+
+	response := types.Response{
+		Result: []types.Result{
+			{
+				Code:    EppOk.Code(),
+				Message: EppOk.Message(),
+			},
+		},
+		ResultData: diResponse,
+		Extension: struct {
+			types.IISExtensionInfoDataType
+			types.DNSSECExtensionInfoDataType
+		}{
+			diIISExtensionResponse,
+			diDNSSECExtensionResponse,
+		},
+	}
+
+	b, _ := Encode(response, ClientXMLAttributes())
+
+	fmt.Println(string(b))
+
+	// Output:
+	// <?xml version="1.0" encoding="UTF-8"?>
+	// <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+	//   <response>
+	//     <result code="1000">
+	//       <msg>Command completed successfully</msg>
+	//     </result>
+	//     <resData>
+	//       <domain:infData xmlns:domain="urn:ietf:params:xml:ns:domain-1.0" xmlns="urn:ietf:params:xml:ns:domain-1.0">
+	//         <domain:name>example.se</domain:name>
+	//         <domain:roid>DOMAIN_0000000000-SE</domain:roid>
+	//         <domain:status s="ok" />
+	//         <domain:host>ns1.example.se</domain:host>
+	//         <domain:host>ns2.example.se</domain:host>
+	//         <domain:clID>Some Client</domain:clID>
+	//         <domain:crID>Some Client</domain:crID>
+	//         <domain:upID>Some Client</domain:upID>
+	//         <domain:authInfo />
+	//       </domain:infData>
+	//     </resData>
+	//     <extension>
+	//       <iis:infData xmlns:iis="urn:se:iis:xml:epp:iis-1.2" xmlns="urn:se:iis:xml:epp:iis-1.2">
+	//         <iis:state>active</iis:state>
+	//       </iis:infData>
+	//       <sec:infData xmlns:sec="urn:ietf:params:xml:ns:secDNS-1.1" xmlns="urn:ietf:params:xml:ns:secDNS-1.1">
+	//         <sec:dsData>
+	//           <sec:keyTag>195550</sec:keyTag>
+	//           <sec:alg>3</sec:alg>
+	//           <sec:digestType>5</sec:digestType>
+	//           <sec:digest>FFAB0102FFAB0102FFAB0102FFAB0102FFAB0102FFAB0102FFAB0102FFAB0102</sec:digest>
+	//         </sec:dsData>
+	//       </sec:infData>
+	//     </extension>
+	//     <trID>
+	//       <clTRID />
+	//       <svTRID />
+	//     </trID>
+	//   </response>
+	// </epp>
 }

--- a/result.go
+++ b/result.go
@@ -153,7 +153,7 @@ func CreateErrorResponse(code ResultCode, reason string) types.Response {
 			{
 				Code:    code.Code(),
 				Message: code.Message(),
-				ExternalValue: types.ExternalErrorValue{
+				ExternalValue: &types.ExternalErrorValue{
 					Reason: reason,
 				},
 			},

--- a/server.go
+++ b/server.go
@@ -171,8 +171,7 @@ func (s *Server) Stop() {
 	log.Print("stopping listener channel")
 	close(s.stopChan)
 
-	for id, session := range s.Sessions {
-		log.Println("stopping", id)
+	for _, session := range s.Sessions {
 		err := session.Close()
 		if err != nil {
 			log.Println("error closing session:", err.Error())

--- a/session.go
+++ b/session.go
@@ -9,7 +9,10 @@ import (
 	xsd "github.com/lestrrat-go/libxml2/xsd"
 )
 
+// HandlerFunc represents a function for an EPP message.
 type HandlerFunc func(*Session, []byte) ([]byte, error)
+
+// GreetFunc represents a function handling a greeting for the EPP server.
 type GreetFunc func(*Session) ([]byte, error)
 
 // Session is an active connection to the EPP server.
@@ -71,10 +74,16 @@ func (s *Session) run() error {
 	for {
 		select {
 		case <-s.stopChan:
+			log.Printf("stopping server, ending session %s", s.SessionID)
+
 			return nil
 		case <-sessionTimeout:
+			log.Printf("session has been active for 1 hour, ending session %s", s.SessionID)
+
 			return nil
 		case <-idleTimeout:
+			log.Printf("session has been idle for 10 minutes, ending session %s", s.SessionID)
+
 			return nil
 		default:
 			// Go on...
@@ -93,6 +102,8 @@ func (s *Session) run() error {
 
 			return err
 		}
+
+		log.Printf("handling incomming message")
 
 		if s.validator != nil {
 			if err := s.validator.Validate(message); err != nil {

--- a/types/contact_auto_generated.go
+++ b/types/contact_auto_generated.go
@@ -1,0 +1,9 @@
+package types
+
+/*
+NOTE! This file is auto generated from another file - DO NOT EDIT!
+
+This file contents has it's source in types/contact.go. All structs with only one
+field and the suffix 'Type' is being added here. The difference is that the
+field XML tag won't have a namespace.
+*/

--- a/types/dnssec.go
+++ b/types/dnssec.go
@@ -1,0 +1,61 @@
+package types
+
+// Name space constant for the extension.
+const (
+	NameSpaceDNSSEC10 = "urn:ietf:params:xml:ns:secDNS-1.0"
+	NameSpaceDNSSEC11 = "urn:ietf:params:xml:ns:secDNS-1.1"
+)
+
+// DNSSECExtensionCreateType implements extension for create from secDNS-1.1
+type DNSSECExtensionCreateType struct {
+	Create DNSSECOrKeyData `xml:"urn:ietf:params:xml:ns:secDNS-1.1 command>extension>create"`
+}
+
+// DNSSECExtensionUpdateType implements extension for Update from secDNS-1.1
+type DNSSECExtensionUpdateType struct {
+	Update DNSSECExtensionUpdate `xml:"urn:ietf:params:xml:ns:secDNS-1.1 command>extension>update"`
+}
+
+// DNSSECExtensionInfoDataType represents extension for info data from secDNS-1.1
+type DNSSECExtensionInfoDataType struct {
+	InfoData DNSSECOrKeyData `xml:"urn:ietf:params:xml:ns:secDNS-1.1 infData"`
+}
+
+// DNSSECOrKeyData represents DNSSEC data or key data.
+type DNSSECOrKeyData struct {
+	MaxSignatureLife int             `xml:"maxSigLife,omitempty"`
+	DNSSECData       []DNSSEC        `xml:"dsData"`
+	KeyData          []DNSSECKeyData `xml:"keyData"`
+}
+
+// DNSSECExtensionUpdate implements extension for update from secDNS-1.1
+type DNSSECExtensionUpdate struct {
+	Remove                 DNSSECRemove    `xml:"rem,omitempty"`
+	Add                    DNSSECOrKeyData `xml:"add,omitempty"`
+	ChangeMaxSignatureLife int             `xml:"chg>maxSigLife,omitempty"`
+	Urgent                 bool            `xml:"urgent,attr"`
+}
+
+// DNSSECRemove represents remove block for DNSSEC extension.
+type DNSSECRemove struct {
+	All        bool            `xml:"all,omitempty"`
+	DNSSECdata []DNSSEC        `xml:"dsData"`
+	KeyData    []DNSSECKeyData `xml:"keyData"`
+}
+
+// DNSSEC represents DNSSEC data.
+type DNSSEC struct {
+	KeyTag     uint           `xml:"keyTag"`
+	Algorithm  uint           `xml:"alg"`
+	DigestType uint           `xml:"digestType"`
+	Digest     string         `xml:"digest"`
+	KeyData    *DNSSECKeyData `xml:"keyData,omitempty"`
+}
+
+// DNSSECKeyData represents key data for DNSSEC.
+type DNSSECKeyData struct {
+	Flags     uint   `xml:"flags"`
+	Protocol  uint   `xml:"protocol"`
+	Algorithm uint   `xml:"alg"`
+	PublicKey string `xml:"pubKey"`
+}

--- a/types/dnssec_auto_generated.go
+++ b/types/dnssec_auto_generated.go
@@ -1,0 +1,24 @@
+package types
+
+/*
+NOTE! This file is auto generated from another file - DO NOT EDIT!
+
+This file contents has it's source in types/dnssec.go. All structs with only one
+field and the suffix 'Type' is being added here. The difference is that the
+field XML tag won't have a namespace.
+*/
+
+// DNSSECExtensionCreateTypeIn represents a namespace agnostic version of DNSSECExtensionCreateType
+type DNSSECExtensionCreateTypeIn struct {
+	Create DNSSECOrKeyData `xml:"command>extension>create"`
+}
+
+// DNSSECExtensionUpdateTypeIn represents a namespace agnostic version of DNSSECExtensionUpdateType
+type DNSSECExtensionUpdateTypeIn struct {
+	Update DNSSECExtensionUpdate `xml:"command>extension>update"`
+}
+
+// DNSSECExtensionInfoDataTypeIn represents a namespace agnostic version of DNSSECExtensionInfoDataType
+type DNSSECExtensionInfoDataTypeIn struct {
+	InfoData DNSSECOrKeyData `xml:"infData"`
+}

--- a/types/domain.go
+++ b/types/domain.go
@@ -241,7 +241,7 @@ type DomainInfoData struct {
 	UpdateDate   *time.Time     `xml:"upDate,omitempty"`
 	ExpireDate   *time.Time     `xml:"exDate,omitempty"`
 	TransferDate *time.Time     `xml:"trDate,omitempty"`
-	AuthInfo     AuthInfo       `xml:"authInfo,omitempty"`
+	AuthInfo     *AuthInfo      `xml:"authInfo,omitempty"`
 }
 
 // DomainPendingActivationNotificationData represents the response data for a

--- a/types/domain.go
+++ b/types/domain.go
@@ -50,30 +50,96 @@ const (
 	DomainTransferServerCancelled DomainTransferStatusType = "serverCancelled"
 )
 
+// DomainCheckType implements extension for check from domain-1.0.
+type DomainCheckType struct {
+	Check DomainCheck `xml:"urn:ietf:params:xml:ns:domain-1.0 command>check>check"`
+}
+
+// DomainCreateType implements extension for create from domain-1.0.
+type DomainCreateType struct {
+	Create DomainCreate `xml:"urn:ietf:params:xml:ns:domain-1.0 command>create>create"`
+}
+
+// DomainDeleteType implements extension for delete from domain-1.0.
+type DomainDeleteType struct {
+	Delete DomainDelete `xml:"urn:ietf:params:xml:ns:domain-1.0 command>create>delete"`
+}
+
+// DomainInfoType implements extension for info from domain-1.0.
+type DomainInfoType struct {
+	Info DomainInfo `xml:"urn:ietf:params:xml:ns:domain-1.0 command>info>info"`
+}
+
+// DomainRenewType implements extension for renew from domain-1.0.
+type DomainRenewType struct {
+	Renew DomainRenew `xml:"urn:ietf:params:xml:ns:domain-1.0 command>renew>renew"`
+}
+
+// DomainTransferType implements extension for transfer from domain-1.0.
+type DomainTransferType struct {
+	Transfer DomainTransfer `xml:"urn:ietf:params:xml:ns:domain-1.0 command>transfer>transfer"`
+}
+
+// DomainUpdateType implements extension for update from domain-1.0.
+type DomainUpdateType struct {
+	Update DomainUpdate `xml:"urn:ietf:params:xml:ns:domain-1.0 command>update>update"`
+}
+
+// DomainChekDataType implements extension for chekData from domain-1.0.
+type DomainChekDataType struct {
+	CheckData DomainCheckData `xml:"urn:ietf:params:xml:ns:domain-1.0 chkData"`
+}
+
+// DomainCreateDataType implements extension for createData from domain-1.0.
+type DomainCreateDataType struct {
+	CreateData DomainCreateData `xml:"urn:ietf:params:xml:ns:domain-1.0 creData"`
+}
+
+// DomainInfoDataType implements extension for infoData from domain-1.0.
+type DomainInfoDataType struct {
+	InfoData DomainInfoData `xml:"urn:ietf:params:xml:ns:domain-1.0 infData"`
+}
+
+// DomainPendingActivationNotificationDataType implements extension for
+// pendingActivationNotificationData from domain-1.0.
+type DomainPendingActivationNotificationDataType struct {
+	PendingActivationNotificationData DomainPendingActivationNotificationData `xml:"urn:ietf:params:xml:ns:domain-1.0 panData"`
+}
+
+// DomainRenewDataType implements extension for renewData from domain-1.0.
+type DomainRenewDataType struct {
+	RenewData DomainRenewData `xml:"urn:ietf:params:xml:ns:domain-1.0 renData"`
+}
+
+// DomainTransferDataType implements extension for transferData from domain-1.0.
+type DomainTransferDataType struct {
+	TransferData DomainTransferData `xml:"urn:ietf:params:xml:ns:domain-1.0 trnData"`
+}
+
 // DomainCheck represents a check for domain(s).
 type DomainCheck struct {
-	Names []string `xml:"command>check>check>name"`
+	Names []string `xml:"name"`
 }
 
 // DomainCreate represents a domain create command.
 type DomainCreate struct {
-	Name       string     `xml:"command>create>create>name"`
-	Period     Period     `xml:"command>create>create>period,omitempty"`
-	NameServer NameServer `xml:"command>create>create>ns,omitempty"`
-	Registrant string     `xml:"command>create>create>registrant,omitempty"`
-	Contacts   []Contact  `xml:"command>create>create>contact,omitempty"`
-	AuthInfo   AuthInfo   `xml:"command>create>create>authInfo,omitempty"`
+	Name       string     `xml:"name"`
+	Period     Period     `xml:"period,omitempty"`
+	NameServer NameServer `xml:"ns,omitempty"`
+	Registrant string     `xml:"registrant,omitempty"`
+	Contacts   []Contact  `xml:"contact,omitempty"`
+	AuthInfo   AuthInfo   `xml:"authInfo,omitempty"`
 }
 
 // DomainDelete represents a domain delete command.
 type DomainDelete struct {
-	Name string `xml:"command>delete>delete>name"`
+	Name string `xml:"name"`
 }
 
 // DomainInfo represents a domain info command.
 type DomainInfo struct {
-	Name     DomainInfoName `xml:"command>info>info>name"`
-	AuthInfo AuthInfo       `xml:"command>create>create>authInfo,omitempty"`
+	Name     DomainInfoName `xml:"name"`
+	AuthInfo AuthInfo       `xml:"authInfo,omitempty"`
 }
 
 // DomainInfoName represents a domain name in a domain info response.
@@ -84,9 +150,9 @@ type DomainInfoName struct {
 
 // DomainRenew represents a domain renew command.
 type DomainRenew struct {
-	Name       string    `xml:"command>renew>renew>name"`
-	ExpireDate time.Time `xml:"command>renew>renew>curExpDate"`
-	Period     Period    `xml:"command>renew>renew>period,omitempty"`
+	Name       string    `xml:"name"`
+	ExpireDate time.Time `xml:"curExpDate"`
+	Period     Period    `xml:"period,omitempty"`
 }
 
 // DomainTransfer represents a domain transfer command.
@@ -149,63 +215,63 @@ type AuthInfo struct {
 
 // DomainCheckData represents the response data for a domain check command.
 type DomainCheckData struct {
-	CheckDomain []CheckType `xml:"chkData>cd"`
+	CheckDomain []CheckType `xml:"cd"`
 }
 
 // DomainCreateData represents the response data for a domain create command.
 type DomainCreateData struct {
-	Name       string    `xml:"creData>name"`
-	CreateDate time.Time `xml:"creData>crDate"`
-	ExpireDate time.Time `xml:"creData>exDate"`
+	Name       string    `xml:"name"`
+	CreateDate time.Time `xml:"crDate"`
+	ExpireDate time.Time `xml:"exDate"`
 }
 
 // DomainInfoData represents the response data for a domain info command.
 type DomainInfoData struct {
-	Name         string         `xml:"infData>name"`
-	ROID         string         `xml:"infData>roid"`
-	Status       []DomainStatus `xml:"infData>status,omitempty"`
-	Registrant   string         `xml:"infData>registrant,omitempty"`
-	Contact      []Contact      `xml:"infData>contact,omitempty"`
-	NameServer   NameServer     `xml:"infData>ns"`
-	Host         []string       `xml:"infData>host,omitempty"`
-	ClientID     string         `xml:"infData>clID"`
-	CreateID     string         `xml:"infData>crID,omitempty"`
-	CreateDate   time.Time      `xml:"infData>crDate,omitempty"`
-	UpdateID     time.Time      `xml:"infData>upID,omitempty"`
-	UpdateDate   time.Time      `xml:"infData>upDate,omitempty"`
-	ExpireDate   time.Time      `xml:"infData>exDate,omitempty"`
-	TransferDate time.Time      `xml:"infData>trDate,omitempty"`
-	AuthInfo     AuthInfo       `xml:"infData>authInfo,omitempty"`
+	Name         string         `xml:"name"`
+	ROID         string         `xml:"roid"`
+	Status       []DomainStatus `xml:"status,omitempty"`
+	Registrant   string         `xml:"registrant,omitempty"`
+	Contact      []Contact      `xml:"contact,omitempty"`
+	NameServer   *NameServer    `xml:"ns,omitempty"`
+	Host         []string       `xml:"host,omitempty"`
+	ClientID     string         `xml:"clID"`
+	CreateID     string         `xml:"crID,omitempty"`
+	CreateDate   *time.Time     `xml:"crDate,omitempty"`
+	UpdateID     string         `xml:"upID,omitempty"`
+	UpdateDate   *time.Time     `xml:"upDate,omitempty"`
+	ExpireDate   *time.Time     `xml:"exDate,omitempty"`
+	TransferDate *time.Time     `xml:"trDate,omitempty"`
+	AuthInfo     AuthInfo       `xml:"authInfo,omitempty"`
 }
 
 // DomainPendingActivationNotificationData represents the response data for a
 // domain pan command.
 type DomainPendingActivationNotificationData struct {
-	Name          PendingActivationNotificationName `xml:"panData>name"`
-	TransactionID string                            `xml:"panData>paTRID"`
-	Date          time.Time                         `xml:"panData>paDate"`
+	Name          PendingActivationNotificationName `xml:"name"`
+	TransactionID string                            `xml:"paTRID"`
+	Date          time.Time                         `xml:"paDate"`
 }
 
 // DomainRenewData represents the response data for a domain renew command.
 type DomainRenewData struct {
-	Name       string    `xml:"renData>name"`
-	ExpireDate time.Time `xml:"renData>exDate"`
+	Name       string    `xml:"name"`
+	ExpireDate time.Time `xml:"exDate"`
 }
 
 // DomainTransferData represents the response data for a domain transfer command.
 type DomainTransferData struct {
-	Name           string                   `xml:"trnData>name"`
-	TransferStatus DomainTransferStatusType `xml:"trnData>trStatus"`
-	RequestingID   string                   `xml:"trnData>reID"`
-	RequestingDate string                   `xml:"trnData>reDate"`
-	ActingID       string                   `xml:"trnData>acID"`
-	ActingDate     string                   `xml:"trnData>acDate"`
-	ExpireDate     string                   `xml:"trnData>exDate,omitempty"`
+	Name           string                   `xml:"name"`
+	TransferStatus DomainTransferStatusType `xml:"trStatus"`
+	RequestingID   string                   `xml:"reID"`
+	RequestingDate string                   `xml:"reDate"`
+	ActingID       string                   `xml:"acID"`
+	ActingDate     string                   `xml:"acDate"`
+	ExpireDate     string                   `xml:"exDate,omitempty"`
 }
 
 // DomainStatus represents statuses for a domain.
 type DomainStatus struct {
 	Status           string           `xml:",chardata"`
 	DomainStatusType DomainStatusType `xml:"s,attr"`
-	Language         string           `xml:"lang,attr"`
+	Language         string           `xml:"lang,attr,omitempty"`
 }

--- a/types/domain_auto_generated.go
+++ b/types/domain_auto_generated.go
@@ -1,0 +1,74 @@
+package types
+
+/*
+NOTE! This file is auto generated from another file - DO NOT EDIT!
+
+This file contents has it's source in types/domain.go. All structs with only one
+field and the suffix 'Type' is being added here. The difference is that the
+field XML tag won't have a namespace.
+*/
+
+// DomainCheckTypeIn represents a namespace agnostic version of DomainCheckType
+type DomainCheckTypeIn struct {
+	Check DomainCheck `xml:"command>check>check"`
+}
+
+// DomainCreateTypeIn represents a namespace agnostic version of DomainCreateType
+type DomainCreateTypeIn struct {
+	Create DomainCreate `xml:"command>create>create"`
+}
+
+// DomainDeleteTypeIn represents a namespace agnostic version of DomainDeleteType
+type DomainDeleteTypeIn struct {
+	Delete DomainDelete `xml:"command>create>delete"`
+}
+
+// DomainInfoTypeIn represents a namespace agnostic version of DomainInfoType
+type DomainInfoTypeIn struct {
+	Info DomainInfo `xml:"command>info>info"`
+}
+
+// DomainRenewTypeIn represents a namespace agnostic version of DomainRenewType
+type DomainRenewTypeIn struct {
+	Renew DomainRenew `xml:"command>renew>renew"`
+}
+
+// DomainTransferTypeIn represents a namespace agnostic version of DomainTransferType
+type DomainTransferTypeIn struct {
+	Transfer DomainTransfer `xml:"command>transfer>transfer"`
+}
+
+// DomainUpdateTypeIn represents a namespace agnostic version of DomainUpdateType
+type DomainUpdateTypeIn struct {
+	Update DomainUpdate `xml:"command>update>update"`
+}
+
+// DomainChekDataTypeIn represents a namespace agnostic version of DomainChekDataType
+type DomainChekDataTypeIn struct {
+	CheckData DomainCheckData `xml:"chkData"`
+}
+
+// DomainCreateDataTypeIn represents a namespace agnostic version of DomainCreateDataType
+type DomainCreateDataTypeIn struct {
+	CreateData DomainCreateData `xml:"creData"`
+}
+
+// DomainInfoDataTypeIn represents a namespace agnostic version of DomainInfoDataType
+type DomainInfoDataTypeIn struct {
+	InfoData DomainInfoData `xml:"infData"`
+}
+
+// DomainPendingActivationNotificationDataTypeIn represents a namespace agnostic version of DomainPendingActivationNotificationDataType
+type DomainPendingActivationNotificationDataTypeIn struct {
+	PendingActivationNotificationData DomainPendingActivationNotificationData `xml:"panData"`
+}
+
+// DomainRenewDataTypeIn represents a namespace agnostic version of DomainRenewDataType
+type DomainRenewDataTypeIn struct {
+	RenewData DomainRenewData `xml:"renData"`
+}
+
+// DomainTransferDataTypeIn represents a namespace agnostic version of DomainTransferDataType
+type DomainTransferDataTypeIn struct {
+	TransferData DomainTransferData `xml:"trnData"`
+}

--- a/types/greeting.go
+++ b/types/greeting.go
@@ -2,19 +2,6 @@ package types
 
 import "time"
 
-// DCPAccessType represents available DCP access types.
-type DCPAccessType string
-
-// Constants representing the string value of DCP access types.
-const (
-	DCPAll              DCPAccessType = "all"
-	DCPNone             DCPAccessType = "none"
-	DCPNull             DCPAccessType = "null"
-	DCPOther            DCPAccessType = "other"
-	DCPPersonal         DCPAccessType = "personal"
-	DCPPersonalAndOther DCPAccessType = "personalAndOther"
-)
-
 // EPPGreeting is the type to represent a greeting from the server.
 type EPPGreeting struct {
 	Greeting Greeting `xml:"greeting"`
@@ -31,7 +18,7 @@ type Greeting struct {
 // ServiceMenu represents tags that may occur in the greeting service tag.
 type ServiceMenu struct {
 	Version           []string           `xml:"version"`
-	Language          []string           `xml:"language"`
+	Language          []string           `xml:"lang"`
 	ObjectURI         []string           `xml:"objURI"`
 	ServiceExtentions []ServiceExtension `xml:"svcExtention"`
 }
@@ -44,51 +31,61 @@ type ServiceExtension struct {
 // DCP (data collection policy) represents the policy declared in the greeting
 // message.
 type DCP struct {
-	Access    DCPAccessType `xml:"access"`
-	Statement DCPStatement  `xml:"statement"`
-	Expiry    DCPExpiry     `xml:"expiry"`
+	Access    DCPAccess    `xml:"access"`
+	Statement DCPStatement `xml:"statement"`
+	Expiry    *DCPExpiry   `xml:"expiry,omitempty"`
+}
+
+// DCPAccess represents the access type.
+type DCPAccess struct {
+	All              *EmptyTag `xml:"all,omitempty"`
+	None             *EmptyTag `xml:"none,omitempty"`
+	Null             *EmptyTag `xml:"null,omitempty"`
+	Other            *EmptyTag `xml:"other,omitempty"`
+	Personal         *EmptyTag `xml:"personal,omitempty"`
+	PersonalAndOther *EmptyTag `xml:"personalAndOther,omitempty"`
 }
 
 // DCPExpiry represent DCP expiry.
 type DCPExpiry struct {
 	Absolute *time.Time `xml:"absoulte"`
-	Relative string     `xml:"relative"` // Format "PnYnMnDTnHnMnS"
+	Relative string     `xml:"relative,omitempty"` // Format "PnYnMnDTnHnMnS"
 }
 
 // DCPStatement represent DCP statements.
 type DCPStatement struct {
-	Purpose   []DCPPurpose   `xml:"purpose"`
-	Recipient []DCPRecipient `xml:"recipient"`
-	Retention []DCPRetention `xml:"retention"`
+	Purpose   DCPPurpose   `xml:"purpose"`
+	Recipient DCPRecipient `xml:"recipient"`
+	Retention DCPRetention `xml:"retention"`
 }
 
 // DCPPurpose represents a DCP purposes.
 type DCPPurpose struct {
-	Admin   string `xml:"admin"`
-	Contact string `xml:"contact"`
-	Other   string `xml:"other"`
-	Prov    string `xml:"prov"`
+	Admin   *EmptyTag `xml:"admin,omitempty"`
+	Contact *EmptyTag `xml:"contact,omitempty"`
+	Other   *EmptyTag `xml:"other,omitempty"`
+	Prov    *EmptyTag `xml:"prov,omitempty"`
 }
 
 // DCPRecipient represents a DCP recipient.
 type DCPRecipient struct {
-	Other     string    `xml:"other"`
+	Other     *EmptyTag `xml:"other"`
 	Ours      []DCPOurs `xml:"ours"`
-	Public    string    `xml:"public"`
-	Same      string    `xml:"same"`
-	Unrelated string    `xml:"unrelated"`
+	Public    *EmptyTag `xml:"public"`
+	Same      *EmptyTag `xml:"same"`
+	Unrelated *EmptyTag `xml:"unrelated"`
 }
 
 // DCPOurs represents the description for DCP ours.
 type DCPOurs struct {
-	RecipientDescription string `xml:"recDesc"`
+	RecipientDescription string `xml:"recDesc,omitempty"`
 }
 
 // DCPRetention represents a DCP retention.
 type DCPRetention struct {
-	Business   string `xml:"business"`
-	Indefinite string `xml:"indefinite"`
-	Legal      string `xml:"legal"`
-	None       string `xml:"none"`
-	Stated     string `xml:"stated"`
+	Business   *EmptyTag `xml:"business"`
+	Indefinite *EmptyTag `xml:"indefinite"`
+	Legal      *EmptyTag `xml:"legal"`
+	None       *EmptyTag `xml:"none"`
+	Stated     *EmptyTag `xml:"stated"`
 }

--- a/types/greeting_auto_generated.go
+++ b/types/greeting_auto_generated.go
@@ -1,0 +1,9 @@
+package types
+
+/*
+NOTE! This file is auto generated from another file - DO NOT EDIT!
+
+This file contents has it's source in types/greeting.go. All structs with only one
+field and the suffix 'Type' is being added here. The difference is that the
+field XML tag won't have a namespace.
+*/

--- a/types/host_auto_generated.go
+++ b/types/host_auto_generated.go
@@ -1,0 +1,9 @@
+package types
+
+/*
+NOTE! This file is auto generated from another file - DO NOT EDIT!
+
+This file contents has it's source in types/host.go. All structs with only one
+field and the suffix 'Type' is being added here. The difference is that the
+field XML tag won't have a namespace.
+*/

--- a/types/iis.go
+++ b/types/iis.go
@@ -1,0 +1,56 @@
+package types
+
+import "time"
+
+// Name space constant for the extension.
+const (
+	NameSpaceIIS12 = "urn:se:iis:xml:epp:iis-1.2"
+)
+
+// IISExtensionCreateType represents the create tag from the iis-1.2 extension.
+type IISExtensionCreateType struct {
+	Create IISExtensionCreate `xml:"urn:se:iis:xml:epp:iis-1.2 command>extension>create"`
+}
+
+// IISExtensionUpdateType represents the update thag from iis-1.2 extension.
+type IISExtensionUpdateType struct {
+	Update IISExtensionUpdate `xml:"urn:se:iis:xml:epp:iis-1.2 command>extension>update"`
+}
+
+// IISExtensionTransferType represents the transfer tag from iis-1.2 extension.
+type IISExtensionTransferType struct {
+	Update IISExtensionUpdate `xml:"urn:se:iis:xml:epp:iis-1.2 command>extension>transfer"`
+}
+
+// IISExtensionInfoDataType represents the infData tag from iis-1.2 extension.
+type IISExtensionInfoDataType struct {
+	InfoData IISExtensionInfoData `xml:"urn:se:iis:xml:epp:iis-1.2 infData"`
+}
+
+// IISExtensionCreate represents the extension data for create.
+type IISExtensionCreate struct {
+	OrganizationNumber string `xml:"orgno,omitempty"`
+	VatNumber          string `xml:"vatno,omitempty"`
+}
+
+// IISExtensionUpdate represents the extension data for update.
+type IISExtensionUpdate struct {
+	VatNumber    string `xml:"vatno,omitempty"`
+	ClientDelete bool   `xml:"clientDelete,omitempty"`
+}
+
+// IISExtensionTransfer represents the extension data for transfer.
+type IISExtensionTransfer struct {
+	NameServer NameServer `xml:"ns"`
+}
+
+// IISExtensionInfoData represents the extension data for infData.
+type IISExtensionInfoData struct {
+	OrganizationNumber string     `xml:"orgno,omitempty"`
+	VatNumber          string     `xml:"vatno,omitempty"`
+	DeactivationDate   *time.Time `xml:"deactDate,omitempty"`
+	DeleteDate         *time.Time `xml:"delDate,omitempty"`
+	ReleaseDate        *time.Time `xml:"relDate,omitempty"`
+	State              string     `xml:"state,omitempty"`
+	ClientDelete       bool       `xml:"clientDelete,omitempty"`
+}

--- a/types/iis_auto_generated.go
+++ b/types/iis_auto_generated.go
@@ -1,0 +1,29 @@
+package types
+
+/*
+NOTE! This file is auto generated from another file - DO NOT EDIT!
+
+This file contents has it's source in types/iis.go. All structs with only one
+field and the suffix 'Type' is being added here. The difference is that the
+field XML tag won't have a namespace.
+*/
+
+// IISExtensionCreateTypeIn represents a namespace agnostic version of IISExtensionCreateType
+type IISExtensionCreateTypeIn struct {
+	Create IISExtensionCreate `xml:"command>extension>create"`
+}
+
+// IISExtensionUpdateTypeIn represents a namespace agnostic version of IISExtensionUpdateType
+type IISExtensionUpdateTypeIn struct {
+	Update IISExtensionUpdate `xml:"command>extension>update"`
+}
+
+// IISExtensionTransferTypeIn represents a namespace agnostic version of IISExtensionTransferType
+type IISExtensionTransferTypeIn struct {
+	Update IISExtensionUpdate `xml:"command>extension>transfer"`
+}
+
+// IISExtensionInfoDataTypeIn represents a namespace agnostic version of IISExtensionInfoDataType
+type IISExtensionInfoDataTypeIn struct {
+	InfoData IISExtensionInfoData `xml:"infData"`
+}

--- a/types/login_auto_generated.go
+++ b/types/login_auto_generated.go
@@ -1,0 +1,9 @@
+package types
+
+/*
+NOTE! This file is auto generated from another file - DO NOT EDIT!
+
+This file contents has it's source in types/login.go. All structs with only one
+field and the suffix 'Type' is being added here. The difference is that the
+field XML tag won't have a namespace.
+*/

--- a/types/poll_auto_generated.go
+++ b/types/poll_auto_generated.go
@@ -1,0 +1,9 @@
+package types
+
+/*
+NOTE! This file is auto generated from another file - DO NOT EDIT!
+
+This file contents has it's source in types/poll.go. All structs with only one
+field and the suffix 'Type' is being added here. The difference is that the
+field XML tag won't have a namespace.
+*/

--- a/types/response.go
+++ b/types/response.go
@@ -5,9 +5,9 @@ import "time"
 // Response represents an EPP response.
 type Response struct {
 	Result        []Result      `xml:"response>result"`
-	MessageQ      MessageQueue  `xml:"response>msgQ"`
-	ResultData    interface{}   `xml:"response>resData"`
-	Extension     interface{}   `xml:"response>extension"`
+	MessageQ      *MessageQueue `xml:"response>msgQ,omitempty"`
+	ResultData    interface{}   `xml:"response>resData,omitempty"`
+	Extension     interface{}   `xml:"response>extension,omitempty"`
 	TransactionID TransactionID `xml:"response>trID"`
 }
 
@@ -19,18 +19,18 @@ type TransactionID struct {
 
 // MessageQueue represents a message queue for client retrieval.
 type MessageQueue struct {
-	QueueDate time.Time `xml:"qDate"`
-	Message   string    `xml:"msg"`
-	Count     int       `xml:"count,attr"`
-	ID        string    `xml:"id,attr"`
+	QueueDate *time.Time `xml:"qDate,omitempty"`
+	Message   string     `xml:"msg,omitempty"`
+	Count     int        `xml:"count,attr"`
+	ID        string     `xml:"id,attr"`
 }
 
 // Result represents the result in a EPP response.
 type Result struct {
-	Code          int                `xml:"code,attr"`
-	Message       string             `xml:"msg"`
-	Value         interface{}        `xml:"value"`
-	ExternalValue ExternalErrorValue `xml:"extValue"`
+	Code          int                 `xml:"code,attr"`
+	Message       string              `xml:"msg"`
+	Value         interface{}         `xml:"value"`
+	ExternalValue *ExternalErrorValue `xml:"extValue,omitempty"`
 }
 
 // ExternalErrorValue represents the response in the extValeu tag.

--- a/types/response.go
+++ b/types/response.go
@@ -13,7 +13,7 @@ type Response struct {
 
 // TransactionID represents transaction IDs for the client and the server.
 type TransactionID struct {
-	ClientTransactionID string `xml:"clTRID"`
+	ClientTransactionID string `xml:"clTRID,omitempty"`
 	ServerTransactionID string `xml:"svTRID"`
 }
 

--- a/types/response_auto_generated.go
+++ b/types/response_auto_generated.go
@@ -1,0 +1,9 @@
+package types
+
+/*
+NOTE! This file is auto generated from another file - DO NOT EDIT!
+
+This file contents has it's source in types/response.go. All structs with only one
+field and the suffix 'Type' is being added here. The difference is that the
+field XML tag won't have a namespace.
+*/

--- a/types/types.go
+++ b/types/types.go
@@ -12,12 +12,10 @@ verification methods.
 
 // Name space constants for the default name spaces
 const (
-	NameSpaceContact  = "urn:ietf:params:xml:ns:contact-1.0"
-	NameSpaceDNSSEC10 = "urn:ietf:params:xml:ns:secDNS-1.0"
-	NameSpaceDNSSEC11 = "urn:ietf:params:xml:ns:secDNS-1.1"
-	NameSpaceDomain   = "urn:ietf:params:xml:ns:domain-1.0"
-	NameSpaceEPP10    = "urn:ietf:params:xml:ns:epp-1.0"
-	NameSpaceHost     = "urn:ietf:params:xml:ns:host-1.0"
+	NameSpaceContact = "urn:ietf:params:xml:ns:contact-1.0"
+	NameSpaceDomain  = "urn:ietf:params:xml:ns:domain-1.0"
+	NameSpaceEPP10   = "urn:ietf:params:xml:ns:epp-1.0"
+	NameSpaceHost    = "urn:ietf:params:xml:ns:host-1.0"
 )
 
 // AliasToNameSpace space will return the full name sapce for a name space alias.

--- a/types/types.go
+++ b/types/types.go
@@ -32,6 +32,11 @@ func AliasToNameSpace(alias string) string {
 	return ""
 }
 
+// EmptyTag represents a tag that can not have any value. This is used for
+// instances to know where a tag was set or not by assigning the parent tag to a
+// pointer to this type.
+type EmptyTag struct{}
+
 // CheckType represents the data from any kind of check command.
 type CheckType struct {
 	Name   CheckName `xml:"name"`

--- a/types/types_auto_generated.go
+++ b/types/types_auto_generated.go
@@ -1,0 +1,9 @@
+package types
+
+/*
+NOTE! This file is auto generated from another file - DO NOT EDIT!
+
+This file contents has it's source in types/types.go. All structs with only one
+field and the suffix 'Type' is being added here. The difference is that the
+field XML tag won't have a namespace.
+*/

--- a/xml/commands/create-contact.xml
+++ b/xml/commands/create-contact.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<epp xmlns:ns0="urn:se:iis:xml:epp:iis-1.2" xmlns="urn:ietf:params:xml:ns:epp-1.0">
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
   <command>
     <create>
       <contact:create xmlns:contact="urn:ietf:params:xml:ns:contact-1.0">
@@ -14,12 +14,15 @@
         </contact:postalInfo>
         <contact:voice>+41.12345689</contact:voice>
         <contact:email>jane@example.se</contact:email>
+        <contact:authInfo>
+          <contact:pw>some-password</contact:pw>
+        </contact:authInfo>
       </contact:create>
     </create>
     <extension>
-      <ns0:create>
-        <ns0:orgno>[SE]555555-1111</ns0:orgno>
-      </ns0:create>
+      <iis:create xmlns:iis="urn:se:iis:xml:epp:iis-1.2">
+        <iis:orgno>[SE]555555-1111</iis:orgno>
+      </iis:create>
     </extension>
     <clTRID>ABC-12345</clTRID>
   </command>

--- a/xml/commands/info-domain.xml
+++ b/xml/commands/info-domain.xml
@@ -3,7 +3,7 @@
   <command>
     <info>
       <domain:info xmlns:domain="urn:ietf:params:xml:ns:domain-1.0" xsi:schemaLocation="urn:ietf:params:xml:ns:domain-1.0  domain-1.0.xsd">
-        <domain:name hosts="all">ns.example.se</domain:name>
+        <domain:name hosts="all">example.se</domain:name>
       </domain:info>
     </info>
     <clTRID>ABC-12345</clTRID>


### PR DESCRIPTION
# WIP only - not ready for merge

So I made some more work regarding the name space aliases to support a more reasonable way of handling namespaces. Since the usage of extensions require support for the same tag under multiple name spaces I added a subset of `iis-1.2` and `secDNS-1.1` to use as POC. I used those extensions in combination with `domain-1.0` so right now domain differs from the other objects and they're all broken in their own ways. :)

So what's going on here is the test to wrap all actual data in a struct which holds the actual name space, i.e. `urn:ietf:params:xml:ns:domain-1.0`. I then use this value to determine if an alias should be setup.

I only had focus on **marshaling** XML wich might be odd since the initial idea of this package was to create a stable server, not a client. I still wanted to start in some end and we'll always be required to marshal proper responses.

So it seems like this method makes things work now with a regular marshal and then some traversing with `xmltree` to set the local alias for each tag, [see example here](https://github.com/bombsimon/epp-go/blob/xml-namespaces/read_write_test.go#L154).

The bad thing with this is that I'm now no longer able to unmarshal any kind of input to the corresponding type. In fact, I can't even unmarshal data with the correct namespace. To solve this I tried to create an anonymous in-place struct ignoring the namespace, [see here](https://github.com/bombsimon/epp-go/blob/xml-namespaces/examples/server/main.go#L178-L180). This doesn't feel right at all but right now I don't have much more details.

I don't want to spend **too** much on this either since it's obvious that this is a known issue, [see here](https://github.com/golang/go/issues/13400). Note that one of the people commenting is not only prividing a workaround with [go-libxml](https://github.com/alexrsagen/go-libxml) but is also using this to implement [RFC 5730](https://tools.ietf.org/html/rfc5730) (EPP).

TL;DR: By wrapping types and setting field tag with namespace combined with `xmltree` we can now create proper and good looking XML **from** the implemented types (domain, DNSSEC, IIS). We still have to figure out how to unmarshal **to** these types independend of how the incomming data is using `xmlns`.

Also note that the `ExampleAddNamespace` test won't work since the output is based on my local commit for `xmltree`, see [this issue](https://github.com/droyo/go-xml/issues/82).